### PR TITLE
Add support for channel joined messages

### DIFF
--- a/client/src/test/scala/org/latestbit/slack/morphism/client/impl/SlackApiHttpProtocolSupportSuite.scala
+++ b/client/src/test/scala/org/latestbit/slack/morphism/client/impl/SlackApiHttpProtocolSupportSuite.scala
@@ -1,0 +1,62 @@
+package org.latestbit.slack.morphism.client.impl
+
+import org.latestbit.slack.morphism.client.SlackApiClientBackend.SttpFutureBackendType
+import org.latestbit.slack.morphism.client.reqresp.conversations.SlackApiConversationsHistoryResponse
+import org.latestbit.slack.morphism.codecs.implicits._
+import org.latestbit.slack.morphism.common.SlackApiResponseMetadata
+import org.latestbit.slack.morphism.events.SlackJoinedChannelMessage
+import org.scalatest.flatspec.AnyFlatSpec
+import sttp.client.Response
+import sttp.client.testing.SttpBackendStub
+import sttp.model.{Header, MediaType, StatusCode, Uri}
+
+
+class SlackApiHttpProtocolSupportSuite extends AnyFlatSpec with SlackApiHttpProtocolSupport {
+
+  val jsonResponse =
+    """
+      |{
+      |  "ok": true,
+      |  "messages": [
+      |    {
+      |      "type": "message",
+      |      "subtype": "channel_join",
+      |      "ts": "1583334580.006700",
+      |      "user": "UID",
+      |      "text": "<@UID> has joined the channel",
+      |      "inviter": "OTHERID"
+      |    }
+      |  ],
+      |  "has_more": true,
+      |  "pin_count": 0,
+      |  "channel_actions_ts": null,
+      |  "channel_actions_count": 0,
+      |  "response_metadata": {
+      |    "next_cursor": "bmV4dF90czoxNTgyOTA3MjU3MDA0NjAw"
+      |  }
+      |}
+      |""".stripMargin
+
+  "The SlackApiHttpProtocolSupport" should "be able to decode an example channel_joined message" in {
+    val testResponse: Response[Either[String, String]] = Response(
+      Right(jsonResponse),
+      StatusCode.notValidated(200),
+      "OK",
+      Seq(Header.contentType(MediaType.ApplicationJson)),
+      List()
+    )
+
+    val result = decodeSlackResponse[SlackApiConversationsHistoryResponse](Uri.notValidated("test"), testResponse)
+
+    val expectedResponse = SlackApiConversationsHistoryResponse(
+      List(SlackJoinedChannelMessage("1583334580.006700", None, None, None, None, None, None, None, Some("<@UID> has joined the channel"), None, "UID", Some("OTHERID"))),
+      Some(true),
+      Some(0),
+      Some(SlackApiResponseMetadata(Some("bmV4dF90czoxNTgyOTA3MjU3MDA0NjAw"), None, None))
+    )
+    
+    assert(result === Right(expectedResponse))
+  }
+
+  override protected implicit val sttpBackend: SttpFutureBackendType = SttpBackendStub.asynchronousFuture
+}

--- a/models/src/main/scala/org/latestbit/slack/morphism/codecs/package.scala
+++ b/models/src/main/scala/org/latestbit/slack/morphism/codecs/package.scala
@@ -528,6 +528,8 @@ package object codecs {
     implicit val decoderSlackMeMessage: Decoder[SlackMeMessage] = deriveDecoder[SlackMeMessage]
     implicit val encoderSlackBotMessage: Encoder.AsObject[SlackBotMessage] = deriveEncoder[SlackBotMessage]
     implicit val decoderSlackBotMessage: Decoder[SlackBotMessage] = deriveDecoder[SlackBotMessage]
+    implicit val encoderSlackChannelJoinMessage: Encoder.AsObject[SlackJoinedChannelMessage] = deriveEncoder[SlackJoinedChannelMessage]
+    implicit val decoderSlackChannelJoinMessage: Decoder[SlackJoinedChannelMessage] = deriveDecoder[SlackJoinedChannelMessage]
 
     implicit val encoderSlackMessageGeneralInfo: Encoder.AsObject[SlackMessageGeneralInfo] =
       deriveEncoder[SlackMessageGeneralInfo]

--- a/models/src/main/scala/org/latestbit/slack/morphism/events/SlackEventCallbackBody.scala
+++ b/models/src/main/scala/org/latestbit/slack/morphism/events/SlackEventCallbackBody.scala
@@ -119,6 +119,22 @@ case class SlackUserMessage(
     with SlackPinnedMessage
     with SlackMessageEvent
 
+@JsonAdt( "channel_join" )
+case class SlackJoinedChannelMessage(
+                             override val ts: String,
+                             override val channel: Option[String] = None,
+                             override val channel_type: Option[String] = None,
+                             override val thread_ts: Option[String] = None,
+                             override val reactions: Option[List[SlackMessageReaction]] = None,
+                             edited: Option[SlackMessageEdited] = None,
+                             reply_count: Option[Long] = None,
+                             replies: Option[List[SlackMessageReplyInfo]] = None,
+                             override val text: Option[String] = None,
+                             override val blocks: Option[List[SlackBlock]] = None,
+                             user: String,
+                             inviter: Option[String]
+                           ) extends SlackMessage
+
 @JsonAdt( "bot_message" )
 case class SlackBotMessage(
     override val ts: String,

--- a/models/src/test/scala/org/latestbit/slack/morphism/coding/SlackMessageTemplatingTestSuite.scala
+++ b/models/src/test/scala/org/latestbit/slack/morphism/coding/SlackMessageTemplatingTestSuite.scala
@@ -145,7 +145,7 @@ class SlackMessageTemplatingTestSuite extends AnyFlatSpec {
   }
 
   it should "support text block interpolators" in {
-    object TestInters extends SlackBlocksTemplateDsl {
+    object TestInters extends `SlackBlocksTemplateDsl` {
       val m1: SlackBlockMarkDownText = md"test"
       val p1: SlackBlockPlainText = pt"test"
 


### PR DESCRIPTION
(https://api.slack.com/events/message/channel_join)


Had a problem where a `client.conversations.history` call was failing because it couldn't decode channel_join messages - after applying the contents of this PR the call succeeded.

I couldn't find any other obvious model tests, so this may not be how you'd like this tested.