### PR TITLE
Add support for bot_add messages.

### DIFF
--- a/models/src/main/scala/org/latestbit/slack/morphism/codecs/package.scala
+++ b/models/src/main/scala/org/latestbit/slack/morphism/codecs/package.scala
@@ -535,6 +535,12 @@ package object codecs {
     implicit val decoderSlackChannelJoinMessage: Decoder[SlackChannelJoinMessage] =
       deriveDecoder[SlackChannelJoinMessage]
 
+    implicit val encoderSlackBotAddMessage: Encoder.AsObject[SlackBotAddMessage] =
+      deriveEncoder[SlackBotAddMessage]
+
+    implicit val decoderSlackBotAddMessage: Decoder[SlackBotAddMessage] =
+      deriveDecoder[SlackBotAddMessage]
+
     implicit val encoderSlackChannelTopicMessage: Encoder.AsObject[SlackChannelTopicMessage] =
       deriveEncoder[SlackChannelTopicMessage]
 

--- a/models/src/main/scala/org/latestbit/slack/morphism/events/SlackEventCallbackBody.scala
+++ b/models/src/main/scala/org/latestbit/slack/morphism/events/SlackEventCallbackBody.scala
@@ -175,6 +175,24 @@ case class SlackChannelJoinMessage(
   override val thread_ts: Option[String] = None
 }
 
+@JsonAdt( "bot_add" )
+case class SlackBotAddMessage(
+    override val ts: String,
+    override val channel: Option[String] = None,
+    override val channel_type: Option[String] = None,
+    override val reactions: Option[List[SlackMessageReaction]] = None,
+    edited: Option[SlackMessageEdited] = None,
+    reply_count: Option[Long] = None,
+    replies: Option[List[SlackMessageReplyInfo]] = None,
+    override val text: Option[String] = None,
+    override val blocks: Option[List[SlackBlock]] = None,
+    user: String,
+    bot_id: Option[String] = None,
+    bot_link: Option[String] = None
+) extends SlackMessage {
+  override val thread_ts: Option[String] = None
+}
+
 @JsonAdt( "channel_topic" )
 case class SlackChannelTopicMessage(
     override val ts: String,

--- a/models/src/test/scala/org/latestbit/slack/morphism/coding/SlackApiRawJsonDecoderTestsSuite.scala
+++ b/models/src/test/scala/org/latestbit/slack/morphism/coding/SlackApiRawJsonDecoderTestsSuite.scala
@@ -25,14 +25,15 @@ import org.latestbit.slack.morphism.events.{
   SlackChannelJoinMessage,
   SlackChannelNameMessage,
   SlackChannelPurposeMessage,
-  SlackChannelTopicMessage
+  SlackChannelTopicMessage,
+  SlackBotAddMessage
 }
 import org.scalatest.flatspec.AnyFlatSpec
 import io.circe.parser._
 
 class SlackApiRawJsonDecoderTestsSuite extends AnyFlatSpec with CirceCodecs {
 
-  "Circe codecs" should "be able to decode a channel history with channel_joined, channel_topic, channel_purpose, channel_name messages" in {
+  "Circe codecs" should "be able to decode a channel history with channel_joined, channel_topic, channel_purpose, channel_name, bot_add messages" in {
 
     val jsonResponse =
       """
@@ -71,6 +72,15 @@ class SlackApiRawJsonDecoderTestsSuite extends AnyFlatSpec with CirceCodecs {
             |            "text": "<@UID> has renamed the channel from \"test\" to \"test2\"",
             |            "old_name": "test",
             |            "name": "test2"
+            |        },
+            |        {
+            |            "type": "message",
+            |            "subtype": "bot_add",
+            |            "ts": "1584537248.001900",
+            |            "user": "UID",
+            |            "text": "added an integration to this channel: <https://org.slack.com/services/bot-id|bot-name>",
+            |            "bot_id": "bot-id",
+            |            "bot_link": "<https://org.slack.com/services/bot-id|bot-name>"
             |        }
             |  ],
             |  "has_more": true,
@@ -109,6 +119,13 @@ class SlackApiRawJsonDecoderTestsSuite extends AnyFlatSpec with CirceCodecs {
           user = "UID",
           old_name = Some( "test" ),
           name = "test2"
+        ),
+        SlackBotAddMessage(
+          ts = "1584537248.001900",
+          text = Some( "added an integration to this channel: <https://org.slack.com/services/bot-id|bot-name>" ),
+          user = "UID",
+          bot_id = Some("bot-id"),
+          bot_link = Some("<https://org.slack.com/services/bot-id|bot-name>")
         )
       ),
       has_more = Some( true ),

--- a/models/src/test/scala/org/latestbit/slack/morphism/coding/SlackApiRawJsonDecoderTestsSuite.scala
+++ b/models/src/test/scala/org/latestbit/slack/morphism/coding/SlackApiRawJsonDecoderTestsSuite.scala
@@ -124,8 +124,8 @@ class SlackApiRawJsonDecoderTestsSuite extends AnyFlatSpec with CirceCodecs {
           ts = "1584537248.001900",
           text = Some( "added an integration to this channel: <https://org.slack.com/services/bot-id|bot-name>" ),
           user = "UID",
-          bot_id = Some("bot-id"),
-          bot_link = Some("<https://org.slack.com/services/bot-id|bot-name>")
+          bot_id = Some( "bot-id" ),
+          bot_link = Some( "<https://org.slack.com/services/bot-id|bot-name>" )
         )
       ),
       has_more = Some( true ),


### PR DESCRIPTION
Found another one!

I can't find a reference in the docs for this one - it seems to be different to https://api.slack.com/events/bot_added - so I've just based the Decoder off the JSON I've got.